### PR TITLE
Specify LC_NUMERIC environment variable in desktop file

### DIFF
--- a/spotify.desktop.in
+++ b/spotify.desktop.in
@@ -3,7 +3,7 @@ Name=Spotify
 GenericName=Music Player
 Comment=Listen to music using Spotify
 Icon=spotify-client
-Exec=/bin/bash spotify %U
+Exec=env LC_NUMERIC=en_US.utf8 /bin/bash spotify %U
 TryExec=/bin/bash
 Terminal=false
 Type=Application


### PR DESCRIPTION
In version 0.9.4.183 I have to set LC_NUMERIC=en_US.utf8 to get the Discover page working reliably.
This was suggested by Spotify employees in this thread: http://community.spotify.com/t5/Help-Desktop-Linux-Mac-and/Discover-page-and-radio-page-not-working-on-Linux-on-my-desktop/m-p/503548#M57375
