### PR TITLE
fix broken RHEL conditional

### DIFF
--- a/configure
+++ b/configure
@@ -208,7 +208,7 @@ fi
 echo $arch
 
 # Check for openlssl-compatibility package on distros determined as RHEL, 
-if [ $dist == "RHEL" ]; then
+if [ "$dist" = "RHEL" ]; then
     # Just to be sure we got what we need, 
     echo -n "Locating rpm-binary:... "
     if command -v rpm &> /dev/null ; then 


### PR DESCRIPTION
`$dist` can be `openSUSE project` on openSUSE systems, so needs to be quoted.

Also, for consistency, and clarity of usage of POSIX vs. non-POSIX style conditionals, it is better to use either `[ a = b ]` or `[[ a == b ]]` rather than mixing the two: `[ a == b ]`
