### PR TITLE
Fix detection for all "Red Hat versions"

### DIFF
--- a/configure
+++ b/configure
@@ -171,7 +171,7 @@ case "$dist" in
 			dist='Ubuntu'
         fi
         ;;
-    CentOS|RedHatEnterpriseServer|RedHatEnterpriseWorkstation)
+    CentOS|RedHat*)
         echo -n "($dist handled as RHEL)..."
         dist='RHEL'
         ;;


### PR DESCRIPTION
Using globbing for detection on Red Hat distros since there are
a couple of them out there (RedHatEnterpriseServer,
RedHatEnterpriseWorkstation, RedHatEnterpriseClient and who knows).
Using RedHat\* should be pretty safe to detect atleast every
Red Hat-version.
